### PR TITLE
Update team info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-# CNSP Workshop Website
+# CNSP Website
 
-Workshop organisers:
-Giovanni Di Liberto, Nathaniel Zuk, Mick Crosse, Aaron Nidiffer, Giorgia Cantisani, Stephanie Haro, Magdalena Kachlicka
+https://cnspworkshop.net/
 
-Website authors:
-Giovanni Di Liberto (first version)
-All organisers have been contributing since
+Currently managed by Magdalena Kachlicka.

--- a/about.html
+++ b/about.html
@@ -58,14 +58,15 @@
         <h5>Our Team:</h5>
         <ul>
           <li><a href="https://diliberg.net">Giovanni Di Liberto (CNSP co-ordinator; Hackathon co-ordinator)</a>: , PhD - Assistant Professor in Intelligent Systems, School of Computer Science and Statistics, Trinity College Institute of Neuroscience, Trinity College Dublin</li>
-          <li><a href="http://mickcrosse.com/">Mick Crosse (Media co-lead)</a>, PhD - Neural Engineer and Reesearch Scientist at SEGOTIA Ltd</li>
-          <li><a href="https://arnndffr.us//">Aaron Nidiffer (Workshop co-ordinator)</a>, PhD - Research Assistant Professor in the Department of Biomedical Engineering, University of Rochester</li>
+          <li><a href="http://mickcrosse.com/">Mick Crosse (Media co-lead)</a>, PhD - Senior Neurotechnology Engineer at Segotia Ltd and Adjunct Assistant Professor at Trinity College Dublin</li>
+          <li><a href="https://arnndffr.us//">Aaron Nidiffer (Workshop co-ordinator)</a>, PhD - Research Assistant Professor at the Del Monte Institute for Neuroscience, University of Rochester</li>
           <li><a href="https://www.natezuk.me/">Nate Zuk</a>, PhD - Senior Lecturer in Psychology and Hearing in the Department of Psychology at Nottingham Trent University</li>
           <li><a href="https://giorgiacantisani.github.io/">Georgia Cantisani</a>, PhD - Postdoctoral Researcher at the École Normale Superieure in Paris</li>
-          <li><a href="https://brain.harvard.edu/hbi_humans/stephanie-haro/">Stephanie Haro</a>, PhD - Postdoctoral Researcher at Harvard Medical School and MIT Lincoln Laboratory</li>
+          <li><a href="https://brain.harvard.edu/hbi_humans/stephanie-haro/">Stephanie Haro</a>, PhD - Postdoctoral Research Associate at Brown University</li>
           <li><a href="https://mkachlicka.github.io/">Magdalena Kachlicka (Media co-lead)</a>, PhD - Postdoctoral Researcher in the Auditory Language Perception Hearing and Attention Lab at Birkbeck University of London</li>
           <li><a href="https://jessb0t.github.io/">Jess Alexander</a> - PhD Student at the University of Texas at Austin</li>
           <li><a href="https://people.epfl.ch/xinyi.guan">Xinyi Guan</a> - PhD student at the École Polytechnique Fédérale de Lausanne (EPFL)</li>
+          <li><a href="https://pnc.unipd.it/phd-students/chu-danna/">Danna Chu</a> - PhD student at the University of Padua</li>
 	  <li><a href="https://diliberg.net/">John O'Doherty</a> - PhD student at Trinity College Dublin</li>
         </ul>
       </p>
@@ -74,7 +75,7 @@
         <h5>CNSP workshops organisers:</h5>
         <ul>
           <li>CNSP hackathon 2025: Giovanni Di Liberto (coordinator), Aaron Nidiffer, Mick Crosse, Nate Zuk, Giorgia Cantisani, Stephanie Haro, Magdalena Kachlicka</li>
-          <li>CNSP workshop 2025: Aaron Nidiffer (coordinator), Giovanni Di Liberto, Mick Crosse, Nate Zuk, Giorgia Cantisani, Stephanie Haro, Magdalena Kachlicka</li>
+          <li>CNSP workshop 2025: Aaron Nidiffer (coordinator), Giovanni Di Liberto, Jess Alexander, Mick Crosse, Nate Zuk, Giorgia Cantisani, Stephanie Haro, Magdalena Kachlicka</li>
           <li>CNSP workshop 2023: Aaron Nidiffer (coordinator), Giovanni Di Liberto, Mick Crosse, Nate Zuk, Giorgia Cantisani, Stephanie Haro</li>
           <li>CNSP workshop 2022: Giovanni Di Liberto (coordinator), Mick Crosse, Nate Zuk, Aaron Nidiffer, Giorgia Cantisani, Stephanie Haro</li>
           <li>CNSP workshop 2021: Giovanni Di Liberto (coordinator), Mick Crosse, Nate Zuk, Aaron Nidiffer</li>


### PR DESCRIPTION
@mkachlicka I took the liberty of updating the team info based on everyone's feedback for the 2025 workshop booklet.  Also, I thought it worthwhile to simplify the readme since the current team information exists elsewhere on the website itself.